### PR TITLE
Fix build on macOS 13

### DIFF
--- a/cctools/otool/print_bitcode.c
+++ b/cctools/otool/print_bitcode.c
@@ -38,7 +38,6 @@
 #include <dlfcn.h>
 #include <xar/xar.h>
 #include "mach-o/loader.h"
-#include "objc/objc-runtime.h"
 #include "stuff/allocate.h"
 #include "stuff/bytesex.h"
 #include "stuff/symbol.h"

--- a/cctools/otool/print_objc.c
+++ b/cctools/otool/print_objc.c
@@ -31,7 +31,6 @@
 #include "stdio.h"
 #include "string.h"
 #include "mach-o/loader.h"
-#include "objc/objc-runtime.h"
 #include "stuff/allocate.h"
 #include "stuff/bytesex.h"
 #include "stuff/symbol.h"


### PR DESCRIPTION
On macOS 13, Gentoo Prefix fails to compile cctools due to missing Blocks support in GCC, creating the following error:

```
/Users/ec2-user/gentoo/MacOSX.sdk/usr/include/objc/runtime.h:373:29: error: expected ')' before '^' token
  373 |                       void (^ _Nonnull block)(Class _Nonnull aClass, BOOL * _Nonnull stop)
      |                             ^
      |                             )
```

Fortunately the header objc-runtime.h is not strictly necessary. As a workaround, stop including objc-runtime.h in print_objc.c and print_bitcode.c.